### PR TITLE
Add evaluation utilities and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-EsiRAG
+# EsiRAG
+
+A lightweight experimental implementation of GraphRAG with entity and relation extraction. The project provides tools to index documents and query them using a knowledge graph backed approach.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+API keys for OpenAI compatible models should be configured via environment variables when running scripts.
+
+## Basic Usage
+
+Use `run.py` to insert a corpus and query it:
+
+```bash
+python run.py --base_url <API_URL> --api_key <KEY> --model <MODEL_NAME> \
+  --corpus <path/to/text> --insert_mode origin --query_mode llm
+```
+
+## Evaluation
+
+An example evaluation script is provided under `experiments/evaluate_entity_extraction.py`. It can run entity and relation extraction on an open dataset such as TACRED or DocRED and report precision, recall and F1 scores.
+
+```bash
+python experiments/evaluate_entity_extraction.py --dataset tacred --split validation --model <MODEL_NAME>
+```

--- a/experiments/evaluate_entity_extraction.py
+++ b/experiments/evaluate_entity_extraction.py
@@ -1,0 +1,90 @@
+import argparse
+from collections import Counter
+from datasets import load_dataset
+from nanographrag_tmp import GraphRAG
+
+
+def load_examples(dataset_name: str, split: str):
+    """Load an open dataset and yield text with entity/relation labels.
+
+    Currently supports the TACRED and DocRED datasets via the HuggingFace
+    `datasets` library. The returned samples follow a unified format:
+    `{text: str, entities: List[str], relations: List[Tuple[str,str,str]]}`.
+    """
+    if dataset_name.lower() == "tacred":
+        ds = load_dataset("tacred", split=split)
+        for example in ds:
+            tokens = example["tokens"]
+            text = " ".join(tokens)
+            subj = " ".join(tokens[example["subj_start"] : example["subj_end"] + 1])
+            obj = " ".join(tokens[example["obj_start"] : example["obj_end"] + 1])
+            entities = [subj, obj]
+            relations = [(subj, obj, example["relation"])]
+            yield {"text": text, "entities": entities, "relations": relations}
+    elif dataset_name.lower() == "docred":
+        ds = load_dataset("docred", split=split)
+        for example in ds:
+            text = " ".join(example["sents"].pop()) if isinstance(example["sents"], list) else " ".join(example["sents"])
+            ents = [m[0] for m in example["vertexSet"]]
+            relations = []
+            for r in example["labels"]:
+                head = ents[r["h"]]
+                tail = ents[r["t"]]
+                relations.append((head, tail, r["r"]))
+            yield {"text": text, "entities": ents, "relations": relations}
+    else:
+        raise ValueError(f"Unsupported dataset {dataset_name}")
+
+
+def evaluate(rag: GraphRAG, samples, mode: str, n: int):
+    true_entities = Counter()
+    pred_entities = Counter()
+    true_relations = Counter()
+    pred_relations = Counter()
+
+    for sample in samples:
+        rag.insert(sample["text"], mode, n)
+        graph = rag.chunk_entity_relation_graph._graph
+        pred_ents = list(graph.nodes())
+        pred_rels = [
+            (u, v, graph.edges[u, v].get("description", "")) for u, v in graph.edges()
+        ]
+        true_entities.update(sample["entities"])
+        pred_entities.update(pred_ents)
+        true_relations.update(sample["relations"])
+        pred_relations.update(pred_rels)
+
+    def _score(true_c, pred_c):
+        tp = sum((true_c & pred_c).values())
+        fp = sum((pred_c - true_c).values())
+        fn = sum((true_c - pred_c).values())
+        precision = tp / (tp + fp + 1e-8)
+        recall = tp / (tp + fn + 1e-8)
+        f1 = 2 * precision * recall / (precision + recall + 1e-8)
+        return precision, recall, f1
+
+    entity_scores = _score(true_entities, pred_entities)
+    relation_scores = _score(true_relations, pred_relations)
+    return entity_scores, relation_scores
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate entity extraction")
+    parser.add_argument("--dataset", choices=["tacred", "docred"], required=True)
+    parser.add_argument("--split", default="validation")
+    parser.add_argument("--mode", default="origin")
+    parser.add_argument("--n", type=int, default=1, help="gleaning iterations")
+    parser.add_argument("--model", required=False, help="LLM model name")
+    args = parser.parse_args()
+
+    rag = GraphRAG()
+    samples = list(load_examples(args.dataset, args.split))
+    ent_scores, rel_scores = evaluate(rag, samples, args.mode, args.n)
+    print("Entity Precision: {:.3f}, Recall: {:.3f}, F1: {:.3f}".format(*ent_scores))
+    print(
+        "Relation Precision: {:.3f}, Recall: {:.3f}, F1: {:.3f}".format(*rel_scores)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/nanographrag_tmp/_op.py
+++ b/nanographrag_tmp/_op.py
@@ -436,6 +436,29 @@ async def extract_entities(
     global_config: dict,
     n:int
 ) -> Union[BaseGraphStorage, None]:
+    """Extract entities and relations from text chunks.
+
+    Parameters
+    ----------
+    chunks : dict
+        Mapping from chunk id to ``TextChunkSchema``.
+    knwoledge_graph_inst : BaseGraphStorage
+        Graph storage instance where nodes and edges will be inserted.
+    entity_vdb : BaseVectorStorage
+        Vector database for entity embeddings.
+    mode : str
+        Extraction mode (``origin``, ``beam`` or ``entropy``).
+    global_config : dict
+        GraphRAG configuration dictionary.
+    n : int
+        Number of iterative gleaning rounds.
+
+    Returns
+    -------
+    BaseGraphStorage | None
+        Updated knowledge graph instance or ``None`` if no entities were
+        extracted.
+    """
     use_llm_func: callable = global_config["best_model_func"]
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
 
@@ -811,8 +834,24 @@ def _pack_single_community_by_sub_communities(
     community: SingleCommunitySchema,
     max_token_size: int,
     already_reports: dict[str, CommunitySchema],
-) -> tuple[str, int]:
-    # TODO
+) -> tuple[str, int, set[str], set[tuple[str, str]]]:
+    """Assemble a community description from its sub communities.
+
+    Parameters
+    ----------
+    community : SingleCommunitySchema
+        Target community.
+    max_token_size : int
+        Token limit for the packed string.
+    already_reports : dict[str, CommunitySchema]
+        Mapping of community id to previously generated reports.
+
+    Returns
+    -------
+    tuple[str, int]
+        The packed CSV description string and its token length along with sets
+        of included node and edge identifiers.
+    """
     all_sub_communities = [
         already_reports[k] for k in community["sub_communities"] if k in already_reports
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+openai
+sentence-transformers
+scikit-learn
+numpy
+networkx
+tiktoken
+datasets
+pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+# create dummy modules before loading utils to avoid dependency errors
+sys.modules.setdefault('numpy', type('Dummy', (), {'ndarray': object}))
+sys.modules.setdefault('tiktoken', type('Dummy', (), {}))
+
+spec = importlib.util.spec_from_file_location(
+    "utils", Path(__file__).resolve().parents[1] / "nanographrag_tmp" / "_utils.py"
+)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+
+def test_check_and_fix_json():
+    broken = '{"a":1,}'
+    fixed = utils.check_and_fix_json(broken)
+    assert fixed.endswith('}')


### PR DESCRIPTION
## Summary
- document project usage and evaluation script
- add `requirements.txt`
- document `extract_entities` and sub-community helper
- implement `evaluate_entity_extraction.py` for TACRED/DocRED datasets
- provide a minimal test for utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a70a732188322839eb5459ef2500b